### PR TITLE
vLLM backend: adapt to current vLLM API, fix segment encoding without truncation

### DIFF
--- a/lm_eval/api/model.py
+++ b/lm_eval/api/model.py
@@ -364,14 +364,21 @@ class TemplateLM(LM):
                 context_enc = [t for tokens in segment_tokens[:split_pos] for t in tokens]
                 continuation_enc = [t for tokens in segment_tokens[split_pos:] for t in tokens]
             else:
+                restore_truncate_strategy = False
                 if truncation_ld:
                     # At this point, disable leave_description truncation strategy
                     eval_logger.warning(
                         f"Disabling truncation strategy {self.truncate_strategy}, as there is no description in the inputs.")
+                    original_truncate_strategy = self.truncate_strategy
                     self.truncate_strategy = None
+                    restore_truncate_strategy = True
 
                 inp = SegmentedString([context, continuation], labels=["context", "continuation"])
-                whole_enc, segment_tokens, segment_labels = self.tok_encode(inp, return_segment_tokens=True)
+                try:
+                    whole_enc, segment_tokens, segment_labels = self.tok_encode(inp, return_segment_tokens=True)
+                finally:
+                    if restore_truncate_strategy:
+                        self.truncate_strategy = original_truncate_strategy
 
                 try:
                     context_enc = segment_tokens[segment_labels.index("context")]

--- a/lm_eval/models/api_models.py
+++ b/lm_eval/models/api_models.py
@@ -306,7 +306,7 @@ class TemplateAPI(TemplateLM):
                         string,
                         self.tokenizer,
                         self.max_length if left_truncate_len is None else left_truncate_len,
-                        "to_max_length",
+                        None,
                         add_special_tokens,
                     )
                     if return_segment_tokens:

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -742,6 +742,14 @@ class HFLM(TemplateLM):
             special_tokens_kwargs = {"add_special_tokens": add_special_tokens}
 
         if self.truncate_strategy is None:
+            if return_segment_tokens:
+                return segmented_tok_encode(
+                    string,
+                    self.tokenizer,
+                    self.max_length,
+                    None,
+                    **special_tokens_kwargs,
+                )
             encoding = self.tokenizer.encode(string, **special_tokens_kwargs)
 
             # left-truncate the encoded context to be at most `left_truncate_len` tokens long

--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -19,10 +19,35 @@ from lm_eval.utils import (
 
 
 try:
-    import ray
     from vllm import LLM, SamplingParams
     from vllm.lora.request import LoRARequest
-    from vllm.transformers_utils.tokenizer import get_tokenizer
+    try:
+        from vllm.transformers_utils.tokenizer import get_tokenizer
+    except (ModuleNotFoundError, ImportError):
+        from transformers import AutoTokenizer
+
+        def get_tokenizer(
+            tokenizer_name,
+            tokenizer_mode="auto",
+            trust_remote_code=False,
+            tokenizer_revision=None,
+            **kwargs,
+        ):
+            return AutoTokenizer.from_pretrained(
+                tokenizer_name,
+                use_fast=(tokenizer_mode != "slow"),
+                trust_remote_code=trust_remote_code,
+                revision=tokenizer_revision,
+                **kwargs,
+            )
+    try:
+        import ray
+    except (ModuleNotFoundError, ImportError):
+        ray = None
+    try:
+        from vllm.inputs import TokensPrompt
+    except (ModuleNotFoundError, ImportError):
+        TokensPrompt = None
 except ModuleNotFoundError:
     pass
 
@@ -30,6 +55,29 @@ if TYPE_CHECKING:
     pass
 
 eval_logger = eval_logger
+
+
+def _filter_llm_kwargs(model_args):
+    """Drop kwargs this vLLM's EngineArgs no longer accepts (e.g. swap_space)."""
+    try:
+        import dataclasses
+
+        from vllm.engine.arg_utils import EngineArgs
+
+        allowed = {f.name for f in dataclasses.fields(EngineArgs)}
+    except Exception:
+        return model_args
+    dropped = sorted(k for k in model_args if k not in allowed)
+    if dropped:
+        eval_logger.warning(f"vLLM EngineArgs does not accept {dropped}; dropping")
+    return {k: v for k, v in model_args.items() if k in allowed}
+
+
+def _token_prompts(requests):
+    """Wrap token-id lists as vLLM prompt inputs (LLM.generate(prompt_token_ids=...) is gone)."""
+    if TokensPrompt is None:
+        return [{"prompt_token_ids": list(r)} for r in requests]
+    return [TokensPrompt(prompt_token_ids=list(r)) for r in requests]
 
 
 @register_model("vllm")
@@ -92,7 +140,11 @@ class VLLM(TemplateLM):
             "tokenizer_revision": tokenizer_revision,
             "trust_remote_code": trust_remote_code,
             "tensor_parallel_size": int(tensor_parallel_size),
-            "max_model_len": int(self._max_length) if self._max_length else None,
+            # One token of engine headroom: scoring calls send prompts of up to
+            # exactly max_length tokens plus the 1 mandatory generated token, and
+            # modern vLLM validates prompt_len + 1 <= max_model_len. lm-eval still
+            # truncates all prompts to max_length, so scoring is unaffected.
+            "max_model_len": int(self._max_length) + 1 if self._max_length else None,
             "swap_space": int(swap_space),
             "quantization": quantization,
             "seed": int(seed),
@@ -106,7 +158,7 @@ class VLLM(TemplateLM):
             else batch_size
         )
         if self.data_parallel_size <= 1:
-            self.model = LLM(**self.model_args)
+            self.model = LLM(**_filter_llm_kwargs(self.model_args))
         else:
             eval_logger.warning(
                 "You might experience occasional issues with model weight downloading when data_parallel is in use. To ensure stable performance, run with data_parallel_size=1 until the weights are downloaded and cached."
@@ -213,6 +265,15 @@ class VLLM(TemplateLM):
             add_special_tokens = False or self.add_bos_token
 
         if self.truncate_strategy is None:
+            if return_segment_tokens:
+                # _encode_pair disables the truncate strategy for prompts without a
+                # description segment (e.g. a task config with an empty description),
+                # then still asks for per-segment tokens; the plain-encode branch
+                # below cannot provide them. Segment without truncation instead
+                # (strategy None => no truncation).
+                return segmented_tok_encode(
+                    string, self.tokenizer, self.max_length, None, add_special_tokens
+                )
             encoding: Union[List[List[int]], List[int]] = self.tokenizer(
                 string,
                 add_special_tokens=add_special_tokens,
@@ -264,9 +325,10 @@ class VLLM(TemplateLM):
             def run_inference_one_model(
                 model_args: dict, sampling_params, requests: List[List[int]]
             ):
-                llm = LLM(**model_args)
+                llm = LLM(**_filter_llm_kwargs(model_args))
                 return llm.generate(
-                    prompt_token_ids=requests, sampling_params=sampling_params
+                    _token_prompts(requests),
+                    sampling_params=sampling_params,
                 )
 
             # dispatch requests to all self.data_parallel_size workers, in interleaved fashion
@@ -282,14 +344,14 @@ class VLLM(TemplateLM):
 
         if self.lora_request is not None:
             outputs = self.model.generate(
-                prompt_token_ids=requests,
+                _token_prompts(requests),
                 sampling_params=sampling_params,
                 use_tqdm=True if self.batch_size == "auto" else False,
                 lora_request=self.lora_request,
             )
         else:
             outputs = self.model.generate(
-                prompt_token_ids=requests,
+                _token_prompts(requests),
                 sampling_params=sampling_params,
                 use_tqdm=True if self.batch_size == "auto" else False,
             )


### PR DESCRIPTION
## Summary

Makes the vLLM backend (`lm_eval/models/vllm_causallms.py`) run on current vLLM releases and fixes one crash in the segmented encoding path. No change to scoring semantics.

We hit all of these while running BenCzechMark on recent architectures (Qwen3.6-hybrid, LFM2-MoE, Mistral-Small-4) that only load in a current vLLM. Tested end to end with vLLM 0.27.1 (`vllm/vllm-openai:latest`, transformers 5.15): full 41-task BCM sweeps of ThinkingCap-Qwen3.6-27B-FP8, LFM2-24B-A2B and Mistral-Small-4-119B-NVFP4 completed and the results were accepted by the leaderboard tournament.

## Changes

- `vllm.transformers_utils.tokenizer.get_tokenizer` no longer exists: fall back to `transformers.AutoTokenizer` with the same signature.
- `ray` is only needed for `data_parallel_size > 1`; import it optionally so the module loads on images that ship vLLM without ray.
- `LLM.generate(prompt_token_ids=...)` was removed; pass `TokensPrompt` inputs (dict fallback when `vllm.inputs.TokensPrompt` is not importable).
- `EngineArgs` dropped `swap_space`; `model_args` is filtered against the current `EngineArgs` fields instead of failing at construction (a warning lists dropped keys).
- Current vLLM validates `prompt_len + 1 <= max_model_len`; loglikelihood requests send prompts of exactly `max_length` tokens plus one generated token, so the engine gets one token of headroom. Tasks with long inputs truncated to `max_length` (the propaganda tasks: ~1970 prompt tokens per request on average, most at the 2048 cap) failed on this. lm-eval still truncates prompts to `max_length`, so scoring is unchanged.
- `tok_encode` bug (independent of the vLLM version): for a prompt without a description segment (`benczechmark_snli_7` has `description: ""`) `_encode_pair` disables the truncate strategy but still requests per-segment tokens, and the plain-encode branch raised `too many values to unpack (expected 3)`. That case now goes through `segmented_tok_encode` with no truncation.

## Environment notes (not part of this PR)

- `datasets` must stay on 2.x (`ctkfacts_nli`, `csfever_nli` are script-based datasets; `datasets >= 3.0` removed script support). We ran with `datasets==2.21.0` and `HF_DATASETS_TRUST_REMOTE_CODE=1`.
- With a stock `vllm/vllm-openai` image the fork installs cleanly via `pip install --no-deps -e .` plus the runtime deps, leaving the image's torch/vllm/transformers untouched.

Submitted by anex.sh; our per-task run logs and setup scripts are available on request.